### PR TITLE
[semver:patch] if no tags, use v0.0.0

### DIFF
--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -14,7 +14,7 @@ steps:
   - run:
       name: Tag version and push tag
       command: |
-        LATESTTAG=$(git describe --tags --abbrev=0 @)
+        LATESTTAG=$(git describe --tags --abbrev=0 @ || echo 'v0.0.0')
         echo "git branch is $(git branch --show-current)"
         echo "Latest tag on branch: $LATESTTAG"
         if [ <<parameters.release-type>> == "minor" ]; then


### PR DESCRIPTION
If there are no tags present on the main branch, then there are no versions yet, so we use v0.0.0 as the oldest version. Next version will end up as v0.1.0 (minor) or v0.0.1 (patch).

Note that if there is a "bad" tag that doesn't match our versioning, it will still fail.