### PR TITLE
fix issue with multiple tags on same commit

### DIFF
--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -14,7 +14,8 @@ steps:
   - run:
       name: Tag version and push tag
       command: |
-        LATESTTAG=$(git describe --tags --abbrev=0 @ || echo 'v0.0.0')
+        LATESTTAG=$(git tag --merged | tail -1)
+        LATESTTAG=${LATESTTAG:-v0.0.0}
         echo "git branch is $(git branch --show-current)"
         echo "Latest tag on branch: $LATESTTAG"
         if [ <<parameters.release-type>> == "minor" ]; then


### PR DESCRIPTION
There's an edge-case bug in taggy-orb — when a commit has TWO tags (e.g `v1.5.0` and `v1.6.0`) [it tends to find the lower tag, increment it, and then ends up trying to re-create the higher tag, and fails.](https://app.circleci.com/pipelines/github/myhelix/patient-results/1016/workflows/b4e75074-9cc7-43a1-ac40-ff3ae00ca8c9/jobs/6878)


Change implementation to avoid that issue
