### PR TITLE
LATESTTAG change to pull actual latest tag

### DIFF
--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -14,7 +14,7 @@ steps:
   - run:
       name: Tag version and push tag
       command: |
-        LATESTTAG=$(git tag --merged | tail -1)
+        LATESTTAG=$(git tag --merged | sort -V | tail -1)
         LATESTTAG=${LATESTTAG:-v0.0.0}
         echo "git branch is $(git branch --show-current)"
         echo "Latest tag on branch: $LATESTTAG"


### PR DESCRIPTION
LATESTTAG=$(git tag --merged | tail -1)

Doesn't always pull the correct version tag.
Ex: returns 1.9.0 instead of 1.10.0
```
1.1.0
1.10.0
1.2.0
...
1.9.0
```
This change adds a version sort prior to tail -1 