### PR TITLE
[semver:minor] use actual latest tag

### DIFF
--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -14,7 +14,7 @@ steps:
   - run:
       name: Tag version and push tag
       command: |
-        LATESTTAG=$(git tag --merged | tail -1)
+        LATESTTAG=$(git tag --merged | sort -V | tail -1)
         LATESTTAG=${LATESTTAG:-v0.0.0}
         echo "git branch is $(git branch --show-current)"
         echo "Latest tag on branch: $LATESTTAG"


### PR DESCRIPTION
semver was mistyped as semvar in the last commit