### PR TITLE
squash

### DIFF
--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -1,10 +1,19 @@
 description: >
   cut a release
 parameters:
+  file:
+    description: version file
+    type: string
+    default: null
+  release-candidate:
+    description: add a release-candidate flag to tag
+    type: boolean
+    default: null
   release-type:
     description: type of release (minor, patch)
     type: enum
-    enum: ['minor', 'patch']
+    enum: ['major', 'minor', 'patch']
+    default: null
   working-directory:
     type: string
 steps:
@@ -12,19 +21,9 @@ steps:
       at: << parameters.working-directory >>
   - checkout
   - run:
-      name: Tag version and push tag
-      command: |
-        LATESTTAG=$(git tag --merged | sort -V | tail -1)
-        LATESTTAG=${LATESTTAG:-v0.0.0}
-        echo "git branch is $(git branch --show-current)"
-        echo "Latest tag on branch: $LATESTTAG"
-        if [ <<parameters.release-type>> == "minor" ]; then
-          # Use awk to increment minor version and set patch version to 0
-          NEWTAG=$(echo "$LATESTTAG" | awk '/v/{split($1,v,/[.]/); $1=v[1]"."++v[2]"."0}1')
-        elif [ <<parameters.release-type>> == "patch" ]; then
-          # Use awk to increment patch version only
-          NEWTAG=$(echo "$LATESTTAG" | awk '/v/{split($1,v,/[.]/); $1=v[1]"."v[2]"."++v[3]}1')
-        fi
-        echo "New tag: $NEWTAG"
-        git tag "$NEWTAG"
-        git push --tags
+      name: Git Tag
+      environment:
+        RELEASE_TYPE: <<parameters.release-type>>
+        RELEASE_CANDIDATE: <<parameters.release-candidate>>
+        FILE: <<parameters.file>>
+      command: <<include(scripts/git_tag.sh)>>

--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -4,16 +4,16 @@ parameters:
   file:
     description: version file
     type: string
-    default: ""
+    default: ''
   release-candidate:
-    description: add a release-candidate flag to tag
-    type: boolean
-    default: ""
+    description: add a release-candidate flag (boolean) to tag
+    type: string
+    default: ''
   release-type:
     description: type of release (minor, patch)
     type: enum
-    enum: ['major', 'minor', 'patch']
-    default: ""
+    enum: ['major', 'minor', 'patch', '']
+    default: ''
   working-directory:
     type: string
 steps:

--- a/src/commands/cut-release.yml
+++ b/src/commands/cut-release.yml
@@ -4,16 +4,16 @@ parameters:
   file:
     description: version file
     type: string
-    default: null
+    default: ""
   release-candidate:
     description: add a release-candidate flag to tag
     type: boolean
-    default: null
+    default: ""
   release-type:
     description: type of release (minor, patch)
     type: enum
     enum: ['major', 'minor', 'patch']
-    default: null
+    default: ""
   working-directory:
     type: string
 steps:

--- a/src/jobs/cut-release.yml
+++ b/src/jobs/cut-release.yml
@@ -7,16 +7,16 @@ parameters:
   file:
     description: version file
     type: string
-    default: ""
+    default: ''
   release-candidate:
-    description: add a release-candidate flag to tag
-    type: boolean
-    default: ""
+    description: add a release-candidate flag (boolean) to tag
+    type: string
+    default: ''
   release-type:
     description: type of release (minor, patch)
     type: enum
-    enum: ['major', 'minor', 'patch']
-    default: ""
+    enum: ['major', 'minor', 'patch', '']
+    default: ''
   working-directory:
     type: string
     default: ~/workdir

--- a/src/jobs/cut-release.yml
+++ b/src/jobs/cut-release.yml
@@ -7,16 +7,16 @@ parameters:
   file:
     description: version file
     type: string
-    default: null
+    default: ""
   release-candidate:
     description: add a release-candidate flag to tag
     type: boolean
-    default: null
+    default: ""
   release-type:
     description: type of release (minor, patch)
     type: enum
     enum: ['major', 'minor', 'patch']
-    default: null
+    default: ""
   working-directory:
     type: string
     default: ~/workdir

--- a/src/jobs/cut-release.yml
+++ b/src/jobs/cut-release.yml
@@ -4,14 +4,25 @@ description: >
 executor: default
 
 parameters:
+  file:
+    description: version file
+    type: string
+    default: null
+  release-candidate:
+    description: add a release-candidate flag to tag
+    type: boolean
+    default: null
   release-type:
     description: type of release (minor, patch)
     type: enum
-    enum: ['minor', 'patch']
+    enum: ['major', 'minor', 'patch']
+    default: null
   working-directory:
     type: string
     default: ~/workdir
 steps:
   - cut-release:
-      working-directory: <<parameters.working-directory>>
+      file: <<parameters.file>>
+      release-candidate: <<parameters.release-candidate>>
       release-type: <<parameters.release-type>>
+      working-directory: <<parameters.working-directory>>

--- a/src/scripts/git_tag.sh
+++ b/src/scripts/git_tag.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# shellcheck disable=SC2004
+
+infer_release_type_from_branch() {
+  # check environment
+  if [[ ! $CIRCLE_BRANCH ]]; then
+    echo "CIRCLE_BRANCH variable required for function infer_release_type_from_branch"
+    exit 1
+  fi
+
+  if [[ $CIRCLE_BRANCH =~ hotfix|patch ]]; then
+    RELEASE_TYPE="patch"
+  elif [[ $CIRCLE_BRANCH =~ minor ]]; then
+    RELEASE_TYPE="minor"
+  elif [[ $CIRCLE_BRANCH =~ major ]]; then
+    RELEASE_TYPE="major"
+  else
+    echo "Unable to infer release-type from branch $CIRCLE_BRANCH"
+    exit 1
+  fi
+  echo "$RELEASE_TYPE"
+}
+
+infer_is_release_candidate_from_branch() {
+  # check environment
+  if [[ ! $CIRCLE_BRANCH ]]; then
+    echo "CIRCLE_BRANCH variable required for function infer_is_release_candidate_from_branch"
+    exit 1
+  fi
+
+  IS_RELEASE_CANDIDATE=$([[ $CIRCLE_BRANCH =~ ^main|master$ ]] && echo false || echo true)
+  echo "$IS_RELEASE_CANDIDATE"
+}
+
+infer_current_version() {
+  CURRENT_VERSION=$(git tag --merged | sort -V | tail -1)
+  CURRENT_VERSION=${CURRENT_VERSION:-v0.0.0}
+  echo "$CURRENT_VERSION"
+}
+
+increment_current_version() {
+  # check environment
+  if [[ ! $CURRENT_VERSION ]]; then
+    echo "CURRENT_VERSION variable required for function increment_current_version"
+    exit 1
+  elif [[ ! $RELEASE_TYPE ]]; then
+    echo "RELEASE_TYPE variable required for function increment_current_version"
+    exit 1
+  fi
+
+  # parse version parts from regex
+  TAG_REGEX='v?([0-9]+)\.([0-9]+)\.([0-9]+)'
+  if [[ "$CURRENT_VERSION" =~ $TAG_REGEX ]]; then
+    major=${BASH_REMATCH[1]}
+    minor=${BASH_REMATCH[2]}
+    patch=${BASH_REMATCH[3]}
+
+    # increment specified version part
+    if [[ $RELEASE_TYPE == "major" ]]; then
+      NEXT_VERSION="v$(($major+1)).0.0"
+    elif [[ $RELEASE_TYPE == "minor" ]]; then
+      NEXT_VERSION="v$major.$(($minor+1)).0"
+    elif [[ $RELEASE_TYPE == "patch" ]]; then
+      NEXT_VERSION="v$major.$minor.$(($patch+1))"
+    else
+      echo "Unknown RELEASE_TYPE $RELEASE_TYPE"
+      exit 1
+    fi
+  else
+    echo "Unable to parse CURRENT_VERSION $CURRENT_VERSION with regex $TAG_REGEX"
+    exit 1
+  fi
+  echo "$NEXT_VERSION"
+}
+
+get_release_candidate() {
+  if [[ ! $NEXT_VERSION ]]; then
+    echo "NEXT_VERSION variable required for function get_release_candidate"
+    exit 1
+  fi
+
+  for i in {1..999}; do
+    RELEASE_CANDIDATE="$NEXT_VERSION-rc$i"
+    [[ ! $(git tag --list "$RELEASE_CANDIDATE") ]] && break
+  done
+  echo "$RELEASE_CANDIDATE"
+}
+
+get_next_version() {
+  # if not provided, infer release type from branch name
+  if [[ ! $RELEASE_TYPE ]]; then
+    RELEASE_TYPE=$(infer_release_type_from_branch)
+  fi
+
+  # if not provided, infer if release is a candidate from branch name
+  if [[ ! $IS_RELEASE_CANDIDATE ]]; then
+    IS_RELEASE_CANDIDATE=$(infer_is_release_candidate_from_branch)
+  fi
+
+  # if specified, use version from file
+  if [[ $FILE ]]; then
+    NEXT_VERSION=$(cat "$FILE")
+  else
+    CURRENT_VERSION=$(infer_current_version)
+    NEXT_VERSION=$(increment_current_version)
+  fi
+
+  # if specified, add release candidate
+  if $IS_RELEASE_CANDIDATE; then
+    NEXT_VERSION=$(get_release_candidate)
+  fi
+  echo "$NEXT_VERSION"
+}
+
+# Will not run if sourced for bats-core tests.
+# View src/tests for more information.
+ORB_TEST_ENV="bats-core"
+if [ "${0#*"$ORB_TEST_ENV"}" == "$0" ]; then
+    NEXT_VERSION=$(get_next_version)
+    git tag -m "Tagging $CIRCLE_BRANCH with $NEXT_VERSION" "$NEXT_VERSION"
+fi

--- a/src/tests/git_tag.bats
+++ b/src/tests/git_tag.bats
@@ -1,0 +1,205 @@
+setup() {
+    source ./src/scripts/git_tag.sh
+}
+
+function test_infer_release_type_from_branch_1 { #@test
+    # test hotfix parsed into patch
+
+    export CIRCLE_BRANCH=hotfix
+    run infer_release_type_from_branch
+    echo "$output"
+    [ "$output" = "patch" ]
+}
+
+function test_infer_release_type_from_branch_2 { #@test
+    # test that CIRCLE_BRANCH must be defined
+
+    unset CIRCLE_BRANCH
+    run infer_release_type_from_branch
+    [ "$status" -eq 1 ]
+    echo "$output"
+    [ "$output" = "CIRCLE_BRANCH variable required for function infer_release_type_from_branch" ]
+}
+
+function test_infer_release_type_from_branch_3 { #@test
+    # test unparsable git branch name
+
+    export CIRCLE_BRANCH=bad
+    run infer_release_type_from_branch
+    [ "$status" -eq 1 ]
+    echo "$output"
+    [ "$output" = "Unable to infer release-type from branch $CIRCLE_BRANCH" ]
+}
+
+function test_infer_is_release_candidate_from_branch_1 { #@test
+    export CIRCLE_BRANCH=main
+    run infer_is_release_candidate_from_branch
+    echo "$output"
+    [ "$output" = false ]
+}
+
+function test_infer_is_release_candidate_from_branch_2 { #@test
+    export CIRCLE_BRANCH=not-main
+    run infer_is_release_candidate_from_branch
+    echo "$output"
+    [ "$output" = true ]
+}
+
+function test_infer_current_version_1 { #@test
+    # no recent tag
+
+    run infer_current_version
+    echo "$output"
+    [ "$output" = "v0.0.0" ]
+}
+
+function test_infer_current_version_2 { #@test
+    # recent tag
+
+    git tag v0.1.0
+    run infer_current_version
+    echo "$output"
+    [ "$output" = "v0.1.0" ]  # track previous 'git tag' L59'
+}
+
+function test_infer_current_version_3 { #@test
+    # recent tag
+
+    git tag v0.2.0
+    run infer_current_version
+    echo "$output"
+    [ "$output" = "v0.2.0" ]  # track previous 'git tag' L59 L68'
+}
+
+function test_increment_current_version_1 { #@test
+    # test bad RELEASE_TYPE value
+
+    export CIRCLE_BRANCH="main"
+    export RELEASE_TYPE="bad"
+    export CURRENT_VERSION="v0.0.0"
+    run increment_current_version
+    [ "$status" -eq 1 ]
+    echo "$output"
+    [ "$output" = "Unknown RELEASE_TYPE bad" ]
+}
+
+function test_increment_current_version_2 { #@test
+    # test bad CURRENT_VERSION tag
+
+    export CIRCLE_BRANCH="main"
+    export RELEASE_TYPE="patch"
+    export CURRENT_VERSION="bad"
+    run increment_current_version
+    [ "$status" -eq 1 ]
+    echo "$output"
+    [ "$output" = "Unable to parse CURRENT_VERSION bad with regex v?([0-9]+)\.([0-9]+)\.([0-9]+)" ]
+}
+
+function test_increment_current_version_3 { #@test
+    # test patch increment
+
+    export CIRCLE_BRANCH="main"
+    export RELEASE_TYPE="patch"
+    export CURRENT_VERSION="v1.2.3"
+    run increment_current_version
+    echo "$output"
+    [ "$output" = "v1.2.4" ]
+}
+
+function test_increment_current_version_4 { #@test
+    # test minor increment
+
+    export CIRCLE_BRANCH="main"
+    export RELEASE_TYPE="minor"
+    export CURRENT_VERSION="v1.2.3"
+    run increment_current_version
+    echo "$output"
+    [ "$output" = "v1.3.0" ]
+}
+
+function test_increment_current_version_5 { #@test
+    # test major increment
+
+    export CIRCLE_BRANCH="main"
+    export RELEASE_TYPE="major"
+    export CURRENT_VERSION="v1.2.3"
+    run increment_current_version
+    echo "$output"
+    [ "$output" = "v2.0.0" ]
+}
+
+function test_increment_current_version_6 { #@test
+    # test multi-number version parts
+
+    export CIRCLE_BRANCH="fix/patch"
+    export RELEASE_TYPE="patch"
+    export IS_RELEASE_CANDIDATE=false
+    export CURRENT_VERSION="v10.21.32"
+    run increment_current_version
+    echo "$output"
+    [ "$output" = "v10.21.33" ]
+}
+
+function test_get_release_candidate_1 { #@test
+    # test release candidate added
+
+    export NEXT_VERSION="v1.2.3"
+    run get_release_candidate
+    echo "$output"
+    [ "$output" = "v1.2.3-rc1" ]   # track previous 'git tag' L59 L68'
+}
+
+function test_get_release_candidate_2 { #@test
+    # test release candidate increment
+
+    export NEXT_VERSION="v0.2.0"
+    git tag "$NEXT_VERSION-rc1"
+
+    run get_release_candidate
+    echo "$output"
+    [ "$output" = "v0.2.0-rc2" ]  # track previous git tag 'L59 L68 L155'
+}
+
+function test_get_next_version_1 { #@test
+    # test IS_RELEASE_CANDIDATE overwrites inferrence
+
+    export RELEASE_TYPE="minor"
+    export CIRCLE_BRANCH="main"  # should not be release-candidate
+    export IS_RELEASE_CANDIDATE=true  # overwrite
+    run get_next_version
+    echo "$output"
+    [ "$output" = "v0.3.0-rc1" ]  # track previous 'git tag' L59 L68 L155'
+}
+
+function test_get_next_version_3 { #@test
+    # test FILE overwrite inferrence
+
+    export IS_RELEASE_CANDIDATE=false
+    export RELEASE_TYPE="patch"
+    export FILE="VERSION"
+
+    echo "v1.0.0" > $FILE
+
+    run get_next_version
+    echo "$output"
+    [ "$output" = "v1.0.0" ]
+}
+
+function test_get_next_version_4 { #@test
+    # test if IS_RELEASE_CANDIDATE not provided, it is inferred
+
+    export RELEASE_TYPE="minor"
+    export CIRCLE_BRANCH="not main"  # should be release-candidate
+    run get_next_version
+    echo "$output"
+    [ "$output" = "v0.3.0-rc1" ]   # track previous 'git tag' L59 L68 L155'
+}
+
+function test_get_next_version_5 { #@test
+    # test if RELEASE_TYPE not provided, it is inferred
+
+    export CIRCLE_BRANCH="patch/not main"  # should be patch increment
+    run get_next_version
+    echo "$output"
+    [ "$output" = "v0.2.1-rc1" ]   # track previous 'git tag' L59 L68 L155'
+}


### PR DESCRIPTION
Update taggy orb default behavior to 
1. Infer release-type from branch name RP-191-hotfix-ot-xyz-abc.
3. Infer release candidate from branch (if not on main, add -rcX to tag)
4. Allow `file` parameter which points allows use of a versoin file (ie. `VERSION`) instead of using `git tag --merge` and incrementing (common BFX workflow).

While these are default behaviors, all inference can be skipped using parameters. Because all existing uses of `taggy-orb` provided parameters (there were no default values in this orb), no existing use cases should break.